### PR TITLE
Update Learn Python NYC's URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,9 @@
 
   <section class="meetups">
     <a href="http://www.nycpython.org">NYC Python</a> &middot;
+    <a href="http://learn.nycpython.org">Learn Python NYC</a> &middot;
     <a href="http://flask-nyc.org">Flask-NYC</a> &middot;
     <a href="http://pygotham.org">PyGotham</a> &middot;
-    <a href="http://www.meetup.com/learn-python-nyc/">Learn Python NYC</a>
   </section>
 
   <section class="contacts">


### PR DESCRIPTION
In addition to updating the URL to the vanity URL, it's location is
being moved to be with the other meetup groups.